### PR TITLE
chore: Catch error for MTU Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Note that running the standalone binaries without root requires some extra capab
 ```sh
 sudo setcap 'cap_net_raw,cap_net_admin+eip' ./ac2mqtt
 ```
+
+### Troubleshooting
+
+**send ATT request failed: io: read/write on closed pipe, mac: xx:xx:xx:xx:xx:xx**
+    
+Your controller is discoverable, but currently connected to by another device, most likely your phone app. Close the app, and try again.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -340,7 +340,7 @@ func (g *Gateway) HandleAdvertisement(adv ble.Advertisement) {
 	// official AC infinity app filters by a 16bit id attached to the BLE
 	// manufacturer data field. Our BLE library doesn't extract it for us
 	// and instead leaves it at the start of the byte array
-	// Official Android App only recignizes two valid length for advertisement
+	// Official Android App only recognizes two valid length for advertisement
 	// packets, so we do the same filtering for robustness
 	// NB: could also filter by manufacturer MAC prefix: "34:85:18"
 	if (len(data) == 19 || len(data) == 29) &&
@@ -367,7 +367,11 @@ func (g *Gateway) onNewDevice(addr ble.Addr, scanData []byte) {
 	log.Trace("connected ", mac)
 
 	// same as AC infinity Android app...
-	client.ExchangeMTU(247)
+	_, err = client.ExchangeMTU(247)
+	if err != nil {
+		log.WithError(err).Warn("Can't exchange MTU with ", mac)
+		return
+	}
 	log.Trace("mtu exchanged ", mac)
 
 	// NB: this is responsible for creating BLE subscribe


### PR DESCRIPTION
docs: add small trouble shooting section

Thanks for this project! Got it connected to my controller this evening after running into the silly error of looking at my controller on my phone while trying to connect!

I found that I was running into an issue with discovering services on the controller that corresponded to this `ATT request failed` error. I noticed that this error was actually happening earlier in the flow, first at the MTU Exchange, and noticed the error wasn't being caught. I added an error check there.

Very open to feedback on this! 

A note: I would love to extend this repo into something that can be used as a go single binary CLI for the controllers. I would think it'd be more appropriate as a separate repo, are you aware of any similar project in Go?